### PR TITLE
Release v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Unreleased
+
+- Nothing yet
+
+# Release v1.0 (31.07.2023)
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# idf-examples-launchpad-ci-action
+This Github Action builds merged binaries of ESP examples and if you use example worklow, uploads them to the Github pages for ESP Launchpad.
+
+# Usage
+
+## Step 1: Setup Github Pages in your repository
+You will have to setup Github Pages in your repository. The binaries will be uploaded to the `gh-pages` branch of your repository if you use example workflow.
+
+## Step 2: Configuration file
+It is important to have `.idf_build_apps.toml` configuration file in the root directory of your repository. This file is used to configure the build process. 
+For further information, please refer to the [documentation](https://docs.espressif.com/projects/idf-build-apps/en/latest/config_file.html).
+
+Example configuration file:
+```toml
+paths = "examples" # Paths to search for buildable projects ["examples", "components"]
+target = "all" # esp32, esp32s2, esp32c3, esp32s3, all...
+recursive = true # Search for buildable projects recursively on the paths
+
+# Configuration file for the build process 
+config = "sdkconfig.defaults"
+```
+**Do not overwrite** `collect-app-info` **and** `build-dir` **options!** They are used by the `idf-build-apps` to collect information about the build and to find the build directory. 
+
+## Inputs
+
+### `idf_version`
+The version of the ESP-IDF to use for building the binaries.
+**Default:** `"latest"`
+
+### `parallel_count`
+The number of parallel builds.
+**Default:** `1`
+
+### `parallel_index`
+The index of the parallel build.
+**Default:** `1`
+
+## Step 3: Create a workflow with ESP-IDF docker container. 
+### Example usage
+
+Basic workflow:
+
+```yaml
+jobs:
+
+  build-and-upload-binaries:
+    strategy:
+      matrix:
+        idf_ver: ["latest"]
+    runs-on: ubuntu-latest
+    container: espressif/idf:${{ matrix.idf_ver }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Action for Building and Uploading Binaries
+        uses: espressif/idf-examples-launchpad-ci-action@v1.0
+        with:
+          idf_version: ${{ matrix.idf_ver }}
+
+      - name: Upload binaries to github pages
+        uses: peaceiris/actions-gh-pages@v3 # Or any other third-party action for uploading files to Github Pages
+        with:
+          github_token: ${{ secrets.github_token }}
+          publish_dir: ./binaries
+```
+
+Workflow with parallel builds:
+
+```yaml
+jobs:
+  build-and-upload-binaries:
+    strategy:
+      matrix:
+        include:
+          - idf_ver: "latest"
+            parallel_count: 2
+            parallel_index: 1
+          - idf_ver: "release-v4.4"
+            parallel_count: 2
+            parallel_index: 2
+    runs-on: ubuntu-latest
+    container: espressif/idf:${{ matrix.idf_ver }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Action for Building and Uploading Binaries
+        uses: espressif/idf-examples-launchpad-ci-action@v1.0
+        with:
+          idf_version: ${{ matrix.idf_ver }}
+          parallel_count: ${{ matrix.parallel_count }}
+          parallel_index: ${{ matrix.parallel_index }}
+
+      - name: Upload binaries to github pages
+        uses: peaceiris/actions-gh-pages@v3 # Or any other third-party action for uploading files to Github Pages
+        with:
+          github_token: ${{ secrets.github_token }}
+          publish_dir: ./binaries
+```
+
+#### Note:
+- The output folder of merged binaries and config.toml is `./binaries`
+- It's not mandatory to upload binaries to the Github Pages, although it is recommended, as the ESP-Launchpad is running under `github.io` domain and it would have problem with CORS, so if you want to use other way of storing your binaries and config.toml you will have to provide CORS headers for the ESP-Launchpad from your storage of choice.
+
+## Step 4: Switch Github Pages to the `gh-pages` branch
+After the action has finished, you will have to switch the Github pages to the `gh-pages` branch. You can do this in the settings of your repository.
+
+## Step 5: Flash your binaries with ESP-Launchpad
+Flashing your binaries using the ESP-Launchpad can be achieved by including a `flashConfigURL` query in the URL. The format for the URL is as follows: `https://espressif.github.io/esp-launchpad/?flashConfigURL=https://{owner}.github.io/{repository_name}/config.toml`.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,43 @@
+name: Action for Building, Merging and Uploading Binaries to Github Pages - ESP Launchpad
+description: 'Builds and uploads binaries to github pages for ESP Launchpad'
+
+inputs:
+  idf_version:
+    description: 'IDF version'
+    required: false
+    default: 'latest'
+  parallel_count:
+    description: 'Number of parallel builds'
+    required: false
+    default: 1
+  parallel_index:
+    description: 'Index of the current parallel build'
+    required: false
+    default: 1
+
+runs:
+  using: 'composite'
+  steps:
+
+    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
+      shell: bash
+
+    - run: echo "IDF_VERSION=${{ inputs.idf_version }}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Build examples
+      shell: bash
+      run: |
+        export IDF_EXTRA_ACTIONS_PATH=${GITHUB_WORKSPACE}/examples
+        ${IDF_PATH}/install.sh --enable-ci
+        . ${IDF_PATH}/export.sh
+        pip install rtoml ruamel.yaml --upgrade
+        echo "Building examples..."
+        idf-build-apps build --collect-app-info out.json --build-dir "build_@w" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
+        echo "Merging binaries and generating config.toml..."
+        python ${GITHUB_ACTION_PATH}/generateFiles.py out.json
+        echo "Done building examples."
+
+branding:
+  icon: 'package'
+  color: 'blue'

--- a/generateFiles.py
+++ b/generateFiles.py
@@ -1,0 +1,148 @@
+import re
+import sys
+import subprocess
+import os
+import rtoml
+import shutil
+
+# Environment variables
+github_repository = os.environ.get('GITHUB_REPOSITORY').split('/')
+idf_version = os.environ.get('IDF_VERSION')
+
+github_owner = github_repository[0]
+github_repo = github_repository[1]
+
+# Root toml object
+toml_obj = {'esp_toml_version': 1.0, 'firmware_images_url': f'https://{github_owner}.github.io/{github_repo}/', 'supported_apps': []}
+
+class App:
+    
+    def __init__(self, app):
+        # App directory
+        self.app_dir = app
+        # Name of the app
+        if app:
+            self.name = app.split('/')[-1]
+        # List of targets (esp32, esp32s2, etc)
+        self.targets = []
+        # List of tuples (kit, target)
+        self.boards = []
+
+current_app = App(None)
+
+# Regex to get the app_dir
+def get_app_dir(line):
+    return re.search(r'"app_dir":\s*"([^"]*)",', line).group(1) if re.search(r'"app_dir":\s*"([^"]*)",', line) else None
+
+# Regex to get the target
+def get_target(line):
+    return re.search(r'"target":\s*"([^"]*)",', line).group(1) if re.search(r'"target":\s*"([^"]*)",', line) else None
+
+# Regex to get the kit
+def get_kit(line):
+    return re.search(r'"config":\s*"([^"]*)",', line).group(1) if re.search(r'"config":\s*"([^"]*)",', line) else None
+
+# Squash the json into a list of apps
+def squash_json(input_str):
+    global current_app
+    # Split the input into lines
+    lines = input_str.splitlines()
+    output_list = []
+    for line in lines:
+        # Get the app_dir
+        app = get_app_dir(line)
+        # If its a not a None and not the same as the current app
+        if current_app.app_dir != app:
+            # Save the previous app
+            if current_app.app_dir:
+                output_list.append(current_app.__dict__)
+            current_app = App(app)
+
+        # If we are building for a kit        
+        if (get_kit(line) != ''):
+            current_app.boards.append((get_kit(line), get_target(line)))
+        # If we are building for targets
+        else:
+            current_app.targets.append(get_target(line))
+
+    # Append last app
+    output_list.append(current_app.__dict__)
+    
+    return output_list
+
+# Merge binaries for each app
+def merge_binaries(apps):
+    os.makedirs('binaries', exist_ok=True)
+    for app in apps:
+        # If we are merging binaries for kits
+        if app.get('boards'):
+            for board in app['boards']:
+                kit = board[0]
+                target = board[1]
+                cmd = ['esptool.py', '--chip', target, 'merge_bin', '-o', f'{app["name"]}-{kit}-{target}-{idf_version}.bin', '@flash_args']
+                cwd = f'{app.get("app_dir")}/build_{kit}'
+                subprocess.run(cmd, cwd=cwd)
+                print(f'Merged binaries for {app["name"]}-{kit}-{target}-{idf_version}.bin')
+                shutil.move(f'{cwd}/{app["name"]}-{kit}-{target}-{idf_version}.bin', 'binaries')
+        # If we are merging binaries for targets
+        else:
+            for target in app['targets']:            
+                cmd = ['esptool.py', '--chip', target, 'merge_bin', '-o', f'{app["name"]}-{target}-{idf_version}.bin', '@flash_args']
+                cwd = f'{app.get("app_dir")}/build'
+                subprocess.run(cmd, cwd=cwd)
+                print(f'Merged binaries for {app["name"]}-{target}-{idf_version}.bin')
+                shutil.move(f'{cwd}/{app["name"]}-{target}-{idf_version}.bin', 'binaries')
+
+# Write a single app to the toml file
+def write_app(app):
+    # If we are working with kits
+    if app.get('boards'):
+        for board in app['boards']:
+            kit = board[0]
+            target = board[1]
+            toml_obj[f'{app["name"]}-{kit}-{idf_version}'] = {}
+            toml_obj[f'{app["name"]}-{kit}-{idf_version}']['chipsets'] = [target]
+            toml_obj[f'{app["name"]}-{kit}-{idf_version}'][f'image.{target}'] = f'{app["name"]}-{kit}-{target}-{idf_version}.bin'
+            toml_obj[f'{app["name"]}-{kit}-{idf_version}']['android_app_url'] = ''
+            toml_obj[f'{app["name"]}-{kit}-{idf_version}']['ios_app_url'] = ''
+    # If we are working with targets
+    else:
+        toml_obj[f'{app["name"]}-{idf_version}'] = {}
+        toml_obj[f'{app["name"]}-{idf_version}']['chipsets'] = app['targets']
+        for target in app['targets']:
+            toml_obj[f'{app["name"]}-{idf_version}'][f'image.{target}'] = f'{app["name"]}-{target}-{idf_version}.bin' 
+        toml_obj[f'{app["name"]}-{idf_version}']['android_app_url'] = ''
+        toml_obj[f'{app["name"]}-{idf_version}']['ios_app_url'] = ''
+
+# Create the config.toml file
+def create_config_toml(apps):
+    for app in apps:
+            if app.get('boards'):
+                toml_obj['supported_apps'].extend([f'{app["name"]}-{board[0]}-{idf_version}' for board in app['boards']])
+            else:
+                toml_obj['supported_apps'].extend([f'{app["name"]}-{idf_version}'])
+            for app in apps:
+                write_app(app)
+
+            with open('binaries/config.toml', 'w') as toml_file:
+                rtoml.dump(toml_obj, toml_file)
+
+            # This is a workaround to remove the quotes around the image.<string> in the config.toml file as dot is not allowed in the key by default            
+            with open('binaries/config.toml', 'r') as toml_file:
+                fixed = replace_image_string(toml_file.read())
+
+            with open('binaries/config.toml', 'w') as toml_file:
+                toml_file.write(fixed)
+
+def replace_image_string(text):
+    # Define the regular expression pattern to find "image.<string>"
+    pattern = r'"(image\.\w+)"'
+    # Use re.sub() to replace the matched pattern with image.<string>
+    result = re.sub(pattern, r'\1', text)
+    return result
+
+# Get the output json file from idf_build_apps, process it, merge binaries and create config.toml
+with open(sys.argv[1], 'r') as file:
+    apps = squash_json(file.read())
+    merge_binaries(apps)
+    create_config_toml(apps)


### PR DESCRIPTION
This MR contains v1.0 release of idf-examples-launchpad-ci-action.

It's purpose is to automate the process of building merged binaries of ESP examples using the idf-build-apps tool and a Python script that merges the binaries and generates a config.toml file. These binaries and config.toml are then uploaded to the GitHub pages dedicated to ESP Launchpad. In general this action simplifies the process of building and publishing binary files for ESP-based projects, making it easier for developers to share their work and showcase examples.

It consists of:
- action.yml:
  - Action itself, it fetches the Python script, builds the examples with idf-build-apps using the configuration defined in `.idf_build_apps.toml`, then uses the Python script responsible for mergeing the binaries and creating config.toml which are uploaded to the github pages
  - Inputs: github token (With privilidges to the github repo in which this action is being used), idf_version (Used to build the binaries), parallel_count (Number of parallel builds), parallel_index (Index of parallel build)

- generateFiles.py:
  -  Python script responsible for processing the output json of idf-build-apps build, merging the binaries and creating config.toml for ESP-Launchpad.