### PR TITLE
ci: change JIRA project to RDT

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JIRA_PASS: ${{ secrets.JIRA_PASS }}
-          JIRA_PROJECT: BSP
+          JIRA_PROJECT: RDT
           JIRA_COMPONENT: GitHub
           JIRA_URL: ${{ secrets.JIRA_URL }}
           JIRA_USER: ${{ secrets.JIRA_USER }}

--- a/.github/workflows/new_issues.yml
+++ b/.github/workflows/new_issues.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JIRA_PASS: ${{ secrets.JIRA_PASS }}
-          JIRA_PROJECT: BSP
+          JIRA_PROJECT: RDT
           JIRA_COMPONENT: GitHub
           JIRA_URL: ${{ secrets.JIRA_URL }}
           JIRA_USER: ${{ secrets.JIRA_USER }}

--- a/.github/workflows/new_prs.yml
+++ b/.github/workflows/new_prs.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JIRA_PASS: ${{ secrets.JIRA_PASS }}
-          JIRA_PROJECT: BSP
+          JIRA_PROJECT: RDT
           JIRA_COMPONENT: GitHub
           JIRA_URL: ${{ secrets.JIRA_URL }}
           JIRA_USER: ${{ secrets.JIRA_USER }}


### PR DESCRIPTION
RDT Jira project is more relevant than the BSP