### PR TITLE
Update idf-build-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This Github Action builds merged binaries of ESP examples and if you use example
 You will have to setup Github Pages in your repository. Switch the Github pages to the branch you are running the workflow on. You can do this in the settings of your repository.
 
 ## Step 2: Configuration file
-It is important to have `.idf_build_apps.toml` configuration file in the root directory of your repository. This file is used to configure the build process. 
-For further information, please refer to the [documentation](https://docs.espressif.com/projects/idf-build-apps/en/latest/config_file.html).
+It is important to have the .idf_build_apps.toml configuration file defined in your repository. By default, this file is expected to be located in the root directory. However, you can specify a different path by using the config_file input in this GitHub Action. This file is used to configure the build process. For further information, please refer to the [documentation](https://docs.espressif.com/projects/idf-build-apps/en/latest/config_file.html).
 
 Example configuration file:
 ```toml
@@ -16,16 +15,20 @@ paths = "examples" # Paths to search for buildable projects ["examples", "compon
 target = "all" # esp32, esp32s2, esp32c3, esp32s3, all...
 recursive = true # Search for buildable projects recursively on the paths
 
-# Configuration file for the build process 
+# Configuration file for the build process
 config = "sdkconfig.defaults"
 ```
-**Do not overwrite** `collect-app-info` **and** `build-dir` **options!** They are used by the `idf-build-apps` to collect information about the build and to find the build directory. 
+**Do not overwrite** `collect-app-info` **and** `build-dir` **options!** They are used by the `idf-build-apps` to collect information about the build and to find the build directory.
 
 ## Inputs
 
 ### `idf_version`
 The version of the ESP-IDF to use for building the binaries.
 **Default:** `"latest"`
+
+### `config_file`
+The path to the `idf_build_apps.toml` configuration file
+**Default** `"./.idf_build_apps.toml"`
 
 ### `parallel_count`
 The number of parallel builds.
@@ -35,7 +38,8 @@ The number of parallel builds.
 The index of the parallel build.
 **Default:** `1`
 
-## Step 3: Create a workflow with ESP-IDF docker container. 
+
+## Step 3: Create a workflow with ESP-IDF docker container.
 ### Example usage
 
 Basic workflow:
@@ -70,7 +74,7 @@ jobs:
     needs: build
 
     permissions:
-      pages: write      
+      pages: write
       id-token: write
 
     environment:
@@ -134,7 +138,7 @@ jobs:
     needs: build
 
     permissions:
-      pages: write      
+      pages: write
       id-token: write
 
     environment:

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,23 @@
 name: Action for Building, Merging and Uploading Binaries to Github Pages - ESP Launchpad
-description: 'Builds and uploads binaries to github pages for ESP Launchpad'
+description: "Builds and uploads binaries to github pages for ESP Launchpad"
 
 inputs:
   idf_version:
-    description: 'IDF version'
+    description: "IDF version"
     required: false
-    default: 'latest'
+    default: "latest"
   parallel_count:
-    description: 'Number of parallel builds'
+    description: "Number of parallel builds"
     required: false
     default: 1
   parallel_index:
-    description: 'Index of the current parallel build'
+    description: "Index of the current parallel build"
     required: false
     default: 1
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
 
@@ -31,7 +30,7 @@ runs:
         export IDF_EXTRA_ACTIONS_PATH=${GITHUB_WORKSPACE}/examples
         ${IDF_PATH}/install.sh --enable-ci
         . ${IDF_PATH}/export.sh
-        pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==1.0.0 
+        pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==2.10.1
         echo "Building examples..."
         idf-build-apps build --collect-app-info out.json --build-dir "build_@w" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
         echo "Merging binaries and generating config.toml..."
@@ -39,5 +38,5 @@ runs:
         echo "Done building examples."
 
 branding:
-  icon: 'package'
-  color: 'blue'
+  icon: "package"
+  color: "blue"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         . ${IDF_PATH}/export.sh
         pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==2.10.1
         echo "Building examples..."
-        idf-build-apps build --collect-app-info out.json --build-dir "build_@w" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
+        idf-build-apps build --collect-app-info out.json --build-dir "build_@w_@t" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
         echo "Merging binaries and generating config.toml..."
         python ${GITHUB_ACTION_PATH}/generateFiles.py out.json
         echo "Done building examples."

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "IDF version"
     required: false
     default: "latest"
+  config_file:
+    description: Configuration file for idf-build-apps
+    required: false
+    default: "./.idf_build_apps.toml"
   parallel_count:
     description: "Number of parallel builds"
     required: false
@@ -32,7 +36,7 @@ runs:
         . ${IDF_PATH}/export.sh
         pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==2.10.1
         echo "Building examples..."
-        idf-build-apps build --collect-app-info out.json --build-dir "build_@w_@t" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
+        idf-build-apps build --collect-app-info out.json --config-file ${{ inputs.config_file }} --build-dir "build_@t_@w" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
         echo "Merging binaries and generating config.toml..."
         python ${GITHUB_ACTION_PATH}/generateFiles.py out.json
         echo "Done building examples."

--- a/generateFiles.py
+++ b/generateFiles.py
@@ -16,7 +16,7 @@ github_repo = github_repository[1]
 toml_obj = {'esp_toml_version': 1.0, 'firmware_images_url': f'https://{github_owner}.github.io/{github_repo}/', 'supported_apps': []}
 
 class App:
-    
+
     def __init__(self, app):
         # App directory
         self.app_dir = app
@@ -58,7 +58,7 @@ def squash_json(input_str):
                 output_list.append(current_app.__dict__)
             current_app = App(app)
 
-        # If we are building for a kit        
+        # If we are building for a kit
         if (get_kit(line) and get_kit(line) != ''):
             current_app.boards.append((get_kit(line), get_target(line)))
         # If we are building for targets
@@ -67,7 +67,7 @@ def squash_json(input_str):
 
     # Append last app
     output_list.append(current_app.__dict__)
-    
+
     return output_list
 
 # Merge binaries for each app
@@ -80,15 +80,15 @@ def merge_binaries(apps):
                 kit = board[0]
                 target = board[1]
                 cmd = ['esptool.py', '--chip', target, 'merge_bin', '-o', f'{app["name"]}-{kit}-{target}-{idf_version}.bin', '@flash_args']
-                cwd = f'{app.get("app_dir")}/build_{kit}'
+                cwd = f'{app.get("app_dir")}/build_{kit}_{target}'
                 subprocess.run(cmd, cwd=cwd)
                 print(f'Merged binaries for {app["name"]}-{kit}-{target}-{idf_version}.bin')
                 shutil.move(f'{cwd}/{app["name"]}-{kit}-{target}-{idf_version}.bin', 'binaries')
         # If we are merging binaries for targets
         else:
-            for target in app['targets']:            
+            for target in app['targets']:
                 cmd = ['esptool.py', '--chip', target, 'merge_bin', '-o', f'{app["name"]}-{target}-{idf_version}.bin', '@flash_args']
-                cwd = f'{app.get("app_dir")}/build'
+                cwd = f'{app.get("app_dir")}/build_{target}'
                 subprocess.run(cmd, cwd=cwd)
                 print(f'Merged binaries for {app["name"]}-{target}-{idf_version}.bin')
                 shutil.move(f'{cwd}/{app["name"]}-{target}-{idf_version}.bin', 'binaries')
@@ -110,7 +110,7 @@ def write_app(app):
         toml_obj[f'{app["name"]}-{idf_version}'] = {}
         toml_obj[f'{app["name"]}-{idf_version}']['chipsets'] = app['targets']
         for target in app['targets']:
-            toml_obj[f'{app["name"]}-{idf_version}'][f'image.{target}'] = f'{app["name"]}-{target}-{idf_version}.bin' 
+            toml_obj[f'{app["name"]}-{idf_version}'][f'image.{target}'] = f'{app["name"]}-{target}-{idf_version}.bin'
         toml_obj[f'{app["name"]}-{idf_version}']['android_app_url'] = ''
         toml_obj[f'{app["name"]}-{idf_version}']['ios_app_url'] = ''
 
@@ -127,7 +127,7 @@ def create_config_toml(apps):
             with open('binaries/config.toml', 'w') as toml_file:
                 rtoml.dump(toml_obj, toml_file)
 
-            # This is a workaround to remove the quotes around the image.<string> in the config.toml file as dot is not allowed in the key by default            
+            # This is a workaround to remove the quotes around the image.<string> in the config.toml file as dot is not allowed in the key by default
             with open('binaries/config.toml', 'r') as toml_file:
                 fixed = replace_image_string(toml_file.read())
 

--- a/generateFiles.py
+++ b/generateFiles.py
@@ -80,7 +80,7 @@ def merge_binaries(apps):
                 kit = board[0]
                 target = board[1]
                 cmd = ['esptool.py', '--chip', target, 'merge_bin', '-o', f'{app["name"]}-{kit}-{target}-{idf_version}.bin', '@flash_args']
-                cwd = f'{app.get("app_dir")}/build_{kit}_{target}'
+                cwd = f'{app.get("app_dir")}/build_{target}_{kit}'
                 subprocess.run(cmd, cwd=cwd)
                 print(f'Merged binaries for {app["name"]}-{kit}-{target}-{idf_version}.bin')
                 shutil.move(f'{cwd}/{app["name"]}-{kit}-{target}-{idf_version}.bin', 'binaries')


### PR DESCRIPTION
## Description

This MR:
- Updates idf-build-apps
- Fixes a bug where the bootloader and partition table have been built into the same directory (resulting only in the last built target working)
- Adds a way to specify a idf-build-apps configuration file path

## Related

* Closes [RDT-961](https://jira.espressif.com:8443/browse/RDT-961)

## Testing

Manually - https://github.com/XDanielPaul/test/actions/runs/14885443333/job/41803686898
