### PR TITLE
chore: Bump idf-build-apps to support idf-ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Nothing yet
 
+# Release v1.0.4 (17.3.2026)
+
+- Bumped idf-build-apps version
+
 # Release v1.0.3 (22.7.2025)
 
 - Fixed a regex for the extraction of config name

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
         export IDF_EXTRA_ACTIONS_PATH=${GITHUB_WORKSPACE}/examples
         ${IDF_PATH}/install.sh --enable-ci
         . ${IDF_PATH}/export.sh
-        pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==2.10.1
+        pip install rtoml ruamel.yaml idf-component-manager idf-build-apps==2.16.0
         echo "Building examples..."
         idf-build-apps build --collect-app-info out.json --config-file ${{ inputs.config_file }} --build-dir "build_@t_@w" --parallel-count ${{ inputs.parallel_count }} --parallel-index ${{ inputs.parallel_index }}
         echo "Merging binaries and generating config.toml..."


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Bump idf-build-apps version to support idf-ci (https://github.com/espressif/esp-bsp/actions/runs/23043764645/job/67371738376)

## Related

* Closes RDT-1456
